### PR TITLE
Adds a build-script

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project name="callingallpapers" default="build" basedir=".">
+    <target name="build" depends="bower" />
+
+    <target name="checkAndBuild" depends="jslint, csslint, build"/>
+
+    <!--
+    This target requires the JSHint-tool to be installed.
+
+    $ npm install -g jshint
+     or
+    $ npm install \-\-save-dev jshint
+    -->
+    <target name="jslint" description="Check for syntax-errors in Javascript">
+        <exec executable="jshint" dir="${phing.dir}" checkreturn="true" logoutput="true">
+            <arg line="public/inc/js"/>
+        </exec>
+    </target>
+
+    <!--
+    This target requires the CSSLint-tool to be installed.
+
+    $ npm install -g csslint
+     or
+    $ npm install \-\-save-dev csslint
+    -->
+    <target name="csslint" description="Check for syntax-errors in CSS">
+        <exec executable="csslint" dir="${phing.dir}" checkreturn="true" logoutput="true">
+            <arg line="public/inc/css"/>
+        </exec>
+    </target>
+
+    <!--
+    This target requires bower to be installed.
+
+    $ npm install -g bower
+     or
+    $ npm install \-\-save-dev bower
+    -->
+    <target name="bower" description="Get Dependencies">
+        <echo>Installing Dependencies using 'bower'</echo>
+        <exec executable="bower" dir="${phing.dir}" checkreturn="true">
+            <arg line="update"/>
+        </exec>
+    </target>
+</project>

--- a/public/inc/js/app.js
+++ b/public/inc/js/app.js
@@ -140,5 +140,5 @@ angular.module('callingallpapers', ['720kb.tooltips'])
 
                 });
             }
-        }
-    })
+        };
+    });


### PR DESCRIPTION
This PR adds a build.xml-File to be executed via phing.

It introduces some dependencies for JS- and CSS-Linting taht are
described in the files comment

For the default target bower has to be available in the path

Fixes for the jslint have been applied
