### PR TITLE
Feature/add atom feed creator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 public/inc/lib
+public/atom.xml
+vendor

--- a/app/Callingallpapers/Console/Command/CreateAtomCommand.php
+++ b/app/Callingallpapers/Console/Command/CreateAtomCommand.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright (c)2015-2015 heiglandreas
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIBILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @category
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright ©2015-2015 Andreas Heigl
+ * @license   http://www.opesource.org/licenses/mit-license.php MIT-License
+ * @version   0.0
+ * @since     12.06.15
+ * @link      https://github.com/heiglandreas/
+ */
+
+namespace Callingallpapers\Console\Command;
+
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class CreateAtomCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('create:atom')
+            ->setDescription('Create an ATOM-feed containing the CfPs known to joind.in')
+            ->addArgument(
+                'path',
+                InputArgument::REQUIRED,
+                'Where do you want the RSS-File stored?'
+            )
+
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $loader = new \Twig_Loader_Filesystem(__DIR__ . '/view');
+        $twig = new \Twig_Environment($loader, array(
+    //        'cache' => sys_get_temp_dir(),
+        ));
+        $output->writeln('fetching data from the joind.in-API');
+
+        $client = new Client();
+        $res = $client->get('http://api.joind.in/v2.1/events?filter=cfp&verbose=yes');
+        if (200 !== $res->getStatusCode()) {
+            throw new \UnexpectedValueException(sprintf(
+                'Expected return code of "200" but got "%s"',
+                $res->getStatusCode()
+            ));
+        };
+
+        $content = json_decode($res->getBody(), true);
+
+        $content = $twig->render('createAtomCommand.tpl', array('events'=> $content['events']));
+
+        $fh = fopen($input->getArgument('path'), 'w+');
+        fwrite($fh, $content);
+        fclose($fh);
+
+        return ;
+    }
+}

--- a/app/Callingallpapers/Console/Command/view/createAtomCommand.tpl
+++ b/app/Callingallpapers/Console/Command/view/createAtomCommand.tpl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <author>
+        <name>Calling all Papers</name>
+    </author>
+    <title>Calling all Papers</title>
+    <id>http://calingallpapers.com</id>
+    <updated>{{"now"|date("c")}}</updated>
+    {% for event in events %}
+    <entry>
+        <title>{{event.name}}</title>
+        <link href="{{event.cfp_url}}"/>
+        <id>{{event.website_uri}}</id>
+        <updated>{{event.cfp_end_date}}</updated>
+        <summary>{{event.description}}</summary>
+    </entry>
+    {% endfor %}
+</feed>

--- a/bin/callingallpapers.php
+++ b/bin/callingallpapers.php
@@ -1,0 +1,12 @@
+#!/usr/bin/env php
+<?php
+// callingallpapers.php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Callingallpapers\Console\Command\CreateAtomCommand;
+use Symfony\Component\Console\Application;
+
+$application = new Application();
+$application->add(new CreateAtomCommand());
+$application->run();

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project name="callingallpapers" default="build" basedir=".">
-    <target name="build" depends="bower" />
+    <target name="build" depends="composer, bower" />
 
     <target name="checkAndBuild" depends="jslint, csslint, build"/>
 
@@ -41,6 +41,26 @@
         <echo>Installing Dependencies using 'bower'</echo>
         <exec executable="bower" dir="${phing.dir}" checkreturn="true">
             <arg line="update"/>
+        </exec>
+    </target>
+
+    <!--
+    This target requires composer to be installed.
+    -->
+    <target name="composer" description=">Get PHP-Dependencies">
+        <echo>Installing PHP-Dependencies using composer</echo>
+        <exec executable="composer" dir="${phing.dir}" checkreturn="true">
+            <arg line="install"/>
+        </exec>
+    </target>
+
+    <!--
+    Create an atom-feed
+    -->
+    <target name="content.atom" description="Create the atom-feed">
+        <echo>Creating the ATOM-feed</echo>
+        <exec executable="php" dir="${phing.dir}" checkreturn="true">
+            <arg line="bin/callingallpapers.php create:atom public/atom.xml"/>
         </exec>
     </target>
 </project>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+    "name" : "joindin/callingallpapers",
+    "type" : "website",
+    "description": "Show Calls for Papers",
+    "keywords": ["cfp", "event", "joindin"],
+    "homepage": "http://github.com/joindin/callingallpapers",
+    "license": "MIT",
+    "authors": [{
+        "name": "Andreas Heigl",
+        "email": "andreas@heigl.org",
+        "homepage": "http://andreas.heigl.org",
+        "role": "Developer"
+    }],
+    "require": {
+        "symfony/console": "^2.7",
+        "guzzlehttp/guzzle": "^6.0",
+        "twig/twig": "^1.18"
+    },
+    "autoload": {
+        "psr-4": {
+            "Callingallpapers\\": "app/Callingallpapers"
+        }
+    }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
         <link rel="stylesheet" href="inc/lib/bootstrap/dist/css/bootstrap.min.css">
         <link rel="stylesheet" href="inc/lib/angular-tooltips/dist/angular-tooltips.min.css">
         <link rel="stylesheet" href="inc/lib/fontawesome/css/font-awesome.min.css">
+        <link rel="alternate" type="application/atom+xml" title="CallingallPapers" href="atom.xml" />
     </head>
     <body>
         <nav class="navbar navbar-default">


### PR DESCRIPTION
This PR adds the possibility to create an ATOM-feed via the command-line from the API-provided data. To create the feed that can be statically served you can call the phing-task "create.atom" once every day
