### PR TITLE
Add loading indicator

### DIFF
--- a/public/inc/js/app.js
+++ b/public/inc/js/app.js
@@ -6,10 +6,14 @@ angular.module('callingallpapers', ['720kb.tooltips', 'ngSanitize', 'ui.bootstra
         $scope.isNavCollapsed = true;
     }])
     .controller('EventsCtrl', ['$scope', '$http', function($scope, $http) {
+        $scope.loading = true;
         $scope.events = [];
         $http.get('https://api.callingallpapers.com/v1/cfp')
             .then(function(eventsResponse) {
                 $scope.events = eventsResponse.data.cfps;
+            })
+            .finally(function() {
+                $scope.loading = false;
             });
     }])
 

--- a/public/index.html
+++ b/public/index.html
@@ -55,6 +55,41 @@
             .label {
                 display: inline-block;
             }
+            .spinner {
+                margin: 25vh auto;
+                text-align: center;
+            }
+            .spinner > div {
+                width: 18px;
+                height: 18px;
+                background-color: #333;
+
+                border-radius: 100%;
+                display: inline-block;
+                -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+                animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+            }
+            .spinner .bounce1 {
+                -webkit-animation-delay: -0.32s;
+                animation-delay: -0.32s;
+            }
+            .spinner .bounce2 {
+                -webkit-animation-delay: -0.16s;
+                animation-delay: -0.16s;
+            }
+            @-webkit-keyframes sk-bouncedelay {
+                0%, 80%, 100% { -webkit-transform: scale(0) }
+                40% { -webkit-transform: scale(1.0) }
+            }
+            @keyframes sk-bouncedelay {
+                0%, 80%, 100% { 
+                    -webkit-transform: scale(0);
+                    transform: scale(0);
+                } 40% { 
+                    -webkit-transform: scale(1.0);
+                    transform: scale(1.0);
+                }
+            }
         </style>
         <!-- endbuild -->
     </head>
@@ -89,6 +124,11 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col-xs-12 col-md-8">
+                    <div class="spinner" ng-show="loading">
+                        <div class="bounce1"></div>
+                        <div class="bounce2"></div>
+                        <div class="bounce3"></div>
+                    </div>
             <p class="alert alert-warning" ng-Show="search">Showing only events containing "<strong>{{search}}</strong>"</p>
             <ul class="media-list" ng-controller="EventsCtrl">
                 <li class="media list-group-item" ng-repeat="event in events | filterCfps:search | orderBy: 'dateCfpEnd' ">


### PR DESCRIPTION
When a user first visits the site, they are presented with a blank content area along with a FAQ which is in the sidebar on large viewports, or what looks like the page's entire body on smaller view.  The API responds in 1-2 seconds on a decent connection, and then Angular takes another second or so to lay out all the divs.  In the best case scenario, the page looks blank or _broken_ for a minimum of 2 seconds.

This PR adds a loading spinner which disappears as soon as the ajax request finishes.  There is still a delay of the content rendering, but I think this is still better than showing nothing.


This seems like it should be a simple change but my limited experience with Angular.js has left me scratching my head.  The spinner never actually shows up, so any help would be appreciated.